### PR TITLE
Add gh extension support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: gh-sync-linux
+          - os: macos-latest
+            name: gh-sync-macos
+          - os: windows-latest
+            name: gh-sync-windows.exe
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pyinstaller
+      - name: Build binary
+        run: pyinstaller --onefile -n ${{ matrix.name }} -p src gh_sync/cli.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: dist/${{ matrix.name }}
+  release:
+    name: Create release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./artifacts/*/*
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+

--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,5 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+gh-sync
+

--- a/gh-sync
+++ b/gh-sync
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+from gh_sync.cli import cli
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- add executable `gh-sync`
- ignore built binaries
- release workflow builds cross-platform binaries using PyInstaller

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878a1f788cc833090dd0090cb5a5392