### PR TITLE
docs: update readme gh extension usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,46 @@
 # gh-sync
 
-GitHub Enterprise ↔ GitHub.com subtree sync tool
+Synchronize a subdirectory of your repository with an external repository using a simple GitHub CLI extension. gh-sync wraps `git subtree` so that you can easily pull and push changes while keeping track of the mapping in `.gh-sync.json`.
 
-```shell
-poetry build
-pipx install dist/gh_sync-0.1.0-py3-none-any.whl
+## Features
+
+- **connect** – register a subdirectory ↔ remote URL mapping
+- **pull** – fetch from the remote and update the subtree
+- **push** – push local changes in the subtree back to the remote
+- **list** – show current mappings
+
+These commands make it straightforward to synchronize only a portion of a large repository with another repository.
+
+## Installation
+
+```bash
+gh extension install <your-namespace>/gh-sync
 ```
+
+or install directly with pipx:
+
+```bash
+pipx install git+https://github.com/<your-namespace>/gh-sync
+```
+
+## Usage
+
+```bash
+# Register a mapping (once)
+gh sync connect web-app git@github.com:ackkerman/ibm-nlo.git --branch dev_ui
+
+# Pull updates from the remote
+gh sync pull web-app
+
+# Push local changes back
+gh sync push web-app
+
+# View mappings
+gh sync list
+```
+
+A `.gh-sync.json` file will be created in your repository root to store mappings. Multiple subdirectories can be managed.
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ These commands make it straightforward to synchronize only a portion of a large 
 ## Installation
 
 ```bash
-gh extension install <your-namespace>/gh-sync
+gh extension install ackkerman/gh-sync
 ```
 
 or install directly with pipx:
 
 ```bash
-pipx install git+https://github.com/<your-namespace>/gh-sync
+pipx install git+https://github.com/ackkerman/gh-sync
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- flesh out the README
- document gh extension usage and subtree sync workflow

## Testing
- `pip install -e .`
- `pip install click pydantic pytest pytest-cov`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c898d1548330966315a418f1bef0