### PR TITLE
Use git config for mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gh-sync
 
-Synchronize a subdirectory of your repository with an external repository using a simple GitHub CLI extension. gh-sync wraps `git subtree` so that you can easily pull and push changes while keeping track of the mapping in `.gh-sync.json`.
+Synchronize a subdirectory of your repository with an external repository using a simple GitHub CLI extension. gh-sync wraps `git subtree` so that you can easily pull and push changes while keeping track of the mapping in your Git configuration.
 
 ## Features
 
@@ -39,7 +39,7 @@ gh sync push web-app
 gh sync list
 ```
 
-A `.gh-sync.json` file will be created in your repository root to store mappings. Multiple subdirectories can be managed.
+Mappings are stored in your repository's Git configuration under the `gh-sync` prefix. Multiple subdirectories can be managed.
 
 ## License
 

--- a/docs/About.md
+++ b/docs/About.md
@@ -45,7 +45,7 @@ gh-sync-rs/
 ├── Cargo.toml
 ├── src/
 │   ├── main.rs          # CLI 定義 & エントリポイント
-│   ├── config.rs        # .gh-sync.json 読み書き
+│   ├── config.rs        # git config 読み書き
 │   └── gitops.rs        # git サブコマンドを薄ラップ
 └── tests/
     └── cli.rs           # end‑to‑end テスト
@@ -80,10 +80,10 @@ predicates  = "3.1"
 
 ```rust
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, path::Path, process::Command};
 
-/// リポジトリ直下に作成される設定ファイル
-pub const CONFIG_FILE: &str = ".gh-sync.json";
+/// git config に保存するプレフィックス
+pub const CONFIG_PREFIX: &str = "gh-sync";
 
 /// 1 マッピング = 1 サブディレクトリ ↔ 1 リモート
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -102,20 +102,68 @@ pub struct Config {
 impl Config {
     /// 読み込み（無ければ空設定）
     pub fn load(repo_root: &Path) -> anyhow::Result<Self> {
-        let path = repo_root.join(CONFIG_FILE);
-        if path.exists() {
-            let txt = fs::read_to_string(path)?;
-            Ok(serde_json::from_str(&txt)?)
-        } else {
-            Ok(Self::default())
+        let out = Command::new("git")
+            .args(["config", "--local", "--get-regexp", "^gh-sync\\."])
+            .current_dir(repo_root)
+            .output()?;
+
+        if !out.status.success() {
+            return Ok(Self::default());
         }
+
+        let stdout = String::from_utf8(out.stdout)?;
+        let mut cfg = Config::default();
+        for line in stdout.lines() {
+            if let Some((key, value)) = line.split_once(' ') {
+                let mut parts = key.split('.');
+                if parts.next() != Some(CONFIG_PREFIX) {
+                    continue;
+                }
+                if let Some(name) = parts.next() {
+                    if let Some(field) = parts.next() {
+                        let entry = cfg
+                            .mappings
+                            .entry(name.to_string())
+                            .or_insert_with(|| Mapping {
+                                subdir: name.to_string(),
+                                remote: String::new(),
+                                url: String::new(),
+                                branch: String::new(),
+                            });
+                        match field {
+                            "remote" => entry.remote = value.to_string(),
+                            "url" => entry.url = value.to_string(),
+                            "branch" => entry.branch = value.to_string(),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        Ok(cfg)
     }
 
-    /// 保存（pretty print）
+    /// 保存
     pub fn save(&self, repo_root: &Path) -> anyhow::Result<()> {
-        let path = repo_root.join(CONFIG_FILE);
-        let txt = serde_json::to_string_pretty(self)?;
-        fs::write(path, txt)?;
+        for (name, m) in &self.mappings {
+            let key_remote = format!("{CONFIG_PREFIX}.{}.remote", name);
+            Command::new("git")
+                .args(["config", "--local", "--replace-all", &key_remote, &m.remote])
+                .current_dir(repo_root)
+                .status()?;
+
+            let key_url = format!("{CONFIG_PREFIX}.{}.url", name);
+            Command::new("git")
+                .args(["config", "--local", "--replace-all", &key_url, &m.url])
+                .current_dir(repo_root)
+                .status()?;
+
+            let key_branch = format!("{CONFIG_PREFIX}.{}.branch", name);
+            Command::new("git")
+                .args(["config", "--local", "--replace-all", &key_branch, &m.branch])
+                .current_dir(repo_root)
+                .status()?;
+        }
         Ok(())
     }
 }
@@ -394,22 +442,16 @@ gh-sync push web-app
 gh-sync list
 ```
 
-実行するとリポジトリ直下に
+実行すると `.git/config` 内に次のようなエントリが保存されるで。
 
-```json
-{
-  "mappings": {
-    "web-app": {
-      "subdir": "web-app",
-      "remote": "ibm-nlo",
-      "url": "git@github.com:ackkerman/ibm-nlo.git",
-      "branch": "dev_ui"
-    }
-  }
-}
+```
+[gh-sync "web-app"]
+    remote = ibm-nlo
+    url = git@github.com:ackkerman/ibm-nlo.git
+    branch = dev_ui
 ```
 
-という `.gh-sync.json` が生成されるで。複数サブディレクトリもカバーできる仕組みや。
+複数サブディレクトリもカバーできる仕組みや。
 
 ---
 
@@ -420,7 +462,7 @@ gh-sync list
 | `status` サブコマンド | `git diff --subtree` を噛ませて差分チェック |
 | `sync`          | pull → push のワンライナー              |
 | コンフリクト検知        | エラーコードを解析して自動 abort & 手順提示       |
-| GitHub Actions  | `.gh-sync.json` を読み取って定期同期       |
+| GitHub Actions  | Git config の `gh-sync.*` を読み取って定期同期 |
 
 ---
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, path::Path, process::Command};
 
-/// リポジトリ直下に作成される設定ファイル
-pub const CONFIG_FILE: &str = ".gh-sync.json";
+/// git config に保存するプレフィックス
+pub const CONFIG_PREFIX: &str = "gh-sync";
 
 /// 1 マッピング = 1 サブディレクトリ ↔ 1 リモート
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -21,20 +21,71 @@ pub struct Config {
 impl Config {
     /// 読み込み（無ければ空設定）
     pub fn load(repo_root: &Path) -> anyhow::Result<Self> {
-        let path = repo_root.join(CONFIG_FILE);
-        if path.exists() {
-            let txt = fs::read_to_string(path)?;
-            Ok(serde_json::from_str(&txt)?)
-        } else {
-            Ok(Self::default())
+        let out = Command::new("git")
+            .args(["config", "--local", "--get-regexp", "^gh-sync\\."])
+            .current_dir(repo_root)
+            .output()?;
+
+        if !out.status.success() {
+            return Ok(Self::default());
         }
+
+        let stdout = String::from_utf8(out.stdout)?;
+        let mut cfg = Config::default();
+
+        for line in stdout.lines() {
+            if let Some((key, value)) = line.split_once(' ') {
+                let mut parts = key.split('.');
+                if parts.next() != Some(CONFIG_PREFIX) {
+                    continue;
+                }
+                if let Some(name) = parts.next() {
+                    if let Some(field) = parts.next() {
+                        let entry = cfg
+                            .mappings
+                            .entry(name.to_string())
+                            .or_insert_with(|| Mapping {
+                                subdir: name.to_string(),
+                                remote: String::new(),
+                                url: String::new(),
+                                branch: String::new(),
+                            });
+                        match field {
+                            "remote" => entry.remote = value.to_string(),
+                            "url" => entry.url = value.to_string(),
+                            "branch" => entry.branch = value.to_string(),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(cfg)
     }
 
-    /// 保存（pretty print）
+    /// 保存
     pub fn save(&self, repo_root: &Path) -> anyhow::Result<()> {
-        let path = repo_root.join(CONFIG_FILE);
-        let txt = serde_json::to_string_pretty(self)?;
-        fs::write(path, txt)?;
+        for (name, m) in &self.mappings {
+            let key_remote = format!("{CONFIG_PREFIX}.{}.remote", name);
+            Command::new("git")
+                .args(["config", "--local", "--replace-all", &key_remote, &m.remote])
+                .current_dir(repo_root)
+                .status()?;
+
+            let key_url = format!("{CONFIG_PREFIX}.{}.url", name);
+            Command::new("git")
+                .args(["config", "--local", "--replace-all", &key_url, &m.url])
+                .current_dir(repo_root)
+                .status()?;
+
+            let key_branch = format!("{CONFIG_PREFIX}.{}.branch", name);
+            Command::new("git")
+                .args(["config", "--local", "--replace-all", &key_branch, &m.branch])
+                .current_dir(repo_root)
+                .status()?;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- migrate mapping storage from `.gh-sync.json` to git config
- update docs and README for new storage format
- adjust tests to initialize a real repo and forward git config calls

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68808795e38483308de208ec2d48a247