### PR TITLE
Add rust target install step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- run `rustup target add` during release builds to install the matrix target

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6880a0cb4dac8330a84401ab464ffc26