### PR TITLE
Fix release asset packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ./artifacts
+      - name: Package assets
+        run: |
+          for dir in ./artifacts/*; do
+            name=$(basename "$dir")
+            tar -czf "${name}.tar.gz" -C "$dir" .
+          done
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          files: ./artifacts/*/*
+          files: |
+            gh-sync-*.tar.gz
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- package build artifacts into tarballs before attaching to releases

## Testing
- `cargo test --locked`


------
https://chatgpt.com/codex/tasks/task_e_6880a44094f88330b4370f8cf624e289