### PR TITLE
Fix release workflow to build CLI extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,58 +1,53 @@
 name: release
-
 on:
   push:
     tags:
-      - 'v*'
-
+      - "v*"
 permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build binaries
-    runs-on: ${{ matrix.os }}
+  release:
+    name: Release binary for multi OS
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            artifact: gh-sync-linux
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact: gh-sync-macos
+            artifact: darwin-amd64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: darwin-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact: gh-sync-windows.exe
+            artifact: windows-amd64.exe
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            artifact: windows-arm64.exe
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: linux-amd64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: linux-arm64
+
+    runs-on: ${{ matrix.os }}
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          override: true
-      - name: Add target
-        run: rustup target add ${{ matrix.target }}
-      - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+          target: ${{ matrix.target }}
+      - uses: actions-rs/cargo@v1
         with:
-          name: ${{ matrix.artifact }}
-          path: target/${{ matrix.target }}/release/gh-sync*
-  release:
-    name: Create release
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }}
+
+      - uses: cli/gh-extension-precompile@v1
         with:
-          path: ./artifacts
-      - name: Create release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: ./artifacts/*/*
-          draft: false
-          prerelease: false
-          generate_release_notes: true
+          build_script_override: "script/build.sh"
+        env:
+          TARGET: ${{ matrix.target }}
+          ARTIFACT: ${{ matrix.artifact }}

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p dist
+ext=""
+if [[ "$ARTIFACT" == *.exe ]]; then
+  ext=".exe"
+fi
+mv "target/${TARGET}/release/gh-sync${ext}" "./dist/${ARTIFACT}"
+


### PR DESCRIPTION
## Summary
- rewrite release workflow for GitHub CLI extension builds
- add build script for gh-extension-precompile action

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_6880a44094f88330b4370f8cf624e289