### PR TITLE
feat: allow custom merge message on pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Synchronize a subdirectory of your repository with an external repository using 
 ## Features
 
 - **connect** – register a subdirectory ↔ remote URL mapping
-- **pull** – fetch from the remote and update the subtree
+- **pull** – fetch from the remote and update the subtree (supports `-m` for merge message)
 - **push** – push local changes in the subtree back to the remote
 - **list** – show current mappings
 - **remove** – delete a mapping
@@ -32,8 +32,8 @@ gh extension install ackkerman/gh-sync
 # Register a mapping (once)
 gh sync connect web-app git@github.com:ackkerman/nlo.git --branch dev_ui
 
-# Pull updates from the remote
-gh sync pull web-app
+# Pull updates from the remote (customize merge message with -m)
+gh sync pull web-app -m "Update from remote"
 
 # Push local changes back
 gh sync push web-app

--- a/docs/About.md
+++ b/docs/About.md
@@ -6,8 +6,8 @@ gh-sync is a lightweight CLI tool for synchronizing a subdirectory of one Git re
 
 - `connect <subdir> <remote_url> [--branch <name>] [--remote <remote>]`  
   Register a mapping between a local subdirectory and a remote repository/branch.
-- `pull <subdir> [--branch <name>]`  
-  Fetch from the configured remote and update the subtree.
+- `pull <subdir> [--branch <name>] [-m <message>]`
+  Fetch from the configured remote and update the subtree using the given merge commit message.
 - `push <subdir> [--branch <name>]`  
   Push local changes in the subtree back to the remote.
 - `remove <subdir>`  
@@ -24,7 +24,7 @@ Mappings are saved under the `gh-sync.*` keys inside `.git/config`. Each section
 gh sync connect web-app git@github.com:example/remote.git --branch main
 
 # Fetch and merge remote changes
-gh sync pull web-app
+gh sync pull web-app -m "Update from remote"
 
 # Push local updates back
 gh sync push web-app

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ enum Commands {
         subdir: String,
         #[arg(short, long)]
         branch: Option<String>,
+        /// merge commit message when pulling
+        #[arg(short, long)]
+        message: Option<String>,
     },
     /// subtree push
     Push {
@@ -89,7 +92,7 @@ fn run() -> Result<()> {
             println!("Connected {subdir} ↔ {remote_url} ({branch})");
         }
 
-        Commands::Pull { subdir, branch } => {
+        Commands::Pull { subdir, branch, message } => {
             let m = cfg
                 .mappings
                 .get(&subdir)
@@ -97,7 +100,7 @@ fn run() -> Result<()> {
 
             let branch = branch.unwrap_or_else(|| m.branch.clone());
             fetch(&repo, &m.remote, &branch)?;
-            subtree_pull(&repo, &m.subdir, &m.remote, &branch)?;
+            subtree_pull(&repo, &m.subdir, &m.remote, &branch, message.as_deref())?;
             println!("Pulled {subdir} from {}/{}", m.remote, branch);
         }
 


### PR DESCRIPTION
## Summary
- add `-m` argument to `pull` to set merge commit message
- support message in git operations
- document custom message usage
- test merge message option

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_6880ac1ab6488330b2c683b6ac43c8f6