### PR TITLE
Make tests cross-platform

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,7 +1,16 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
+use std::path::PathBuf;
 use tempfile::tempdir;
+
+fn path_vars(shim: &PathBuf) -> (std::ffi::OsString, std::ffi::OsString) {
+    let orig = std::env::var_os("PATH").unwrap();
+    let mut paths = std::env::split_paths(&orig).collect::<Vec<_>>();
+    paths.insert(0, shim.parent().unwrap().into());
+    let joined = std::env::join_paths(paths).unwrap();
+    (joined, orig)
+}
 
 fn setup_repo() -> tempfile::TempDir {
     let dir = tempdir().unwrap();
@@ -15,13 +24,20 @@ fn setup_repo() -> tempfile::TempDir {
 }
 
 /// `git` 実行を丸ごとエコーに差し替えて成功を偽装
-fn fake_git_path(dir: &tempfile::TempDir) -> std::path::PathBuf {
+fn fake_git_path(dir: &tempfile::TempDir) -> PathBuf {
+    #[cfg(windows)]
+    let shim = dir.path().join("git.cmd");
+    #[cfg(not(windows))]
     let shim = dir.path().join("git");
-    fs::write(
-        &shim,
-        "#!/usr/bin/env sh\nif [ \"$1\" = \"config\" ]; then\n    /usr/bin/git \"$@\"\nelse\n    echo git \"$@\"\nfi\n",
-    )
-    .unwrap();
+
+    let script = if cfg!(windows) {
+        "@echo off\r\nif \"%1\"==\"config\" (\r\n  set \"PATH=%ORIG_PATH%\"\r\n  git %*\r\n) else (\r\n  echo git %*\r\n  exit /b 0\r\n)"
+    } else {
+        "#!/usr/bin/env sh\nif [ \"$1\" = \"config\" ]; then\n  PATH=\"$ORIG_PATH\" git \"$@\"\nelse\n  echo git \"$@\"\nfi\n"
+    };
+
+    fs::write(&shim, script).unwrap();
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -31,25 +47,32 @@ fn fake_git_path(dir: &tempfile::TempDir) -> std::path::PathBuf {
 }
 
 /// `git subtree pull` を失敗させ、add へフォールバックさせるためのシム
-fn fake_git_fail_pull(dir: &tempfile::TempDir) -> std::path::PathBuf {
+fn fake_git_fail_pull(dir: &tempfile::TempDir) -> PathBuf {
+    #[cfg(windows)]
+    let shim = dir.path().join("git.cmd");
+    #[cfg(not(windows))]
     let shim = dir.path().join("git");
-    fs::write(
-        &shim,
+
+    let script = if cfg!(windows) {
+        "@echo off\r\nif \"%1\"==\"config\" (\r\n  set \"PATH=%ORIG_PATH%\"\r\n  git %*\r\n) else if \"%1\"==\"remote\" if \"%2\"==\"get-url\" (\r\n  exit /b 1\r\n) else if \"%1\"==\"subtree\" if \"%2\"==\"pull\" (\r\n  echo hint: use 'git subtree add' 1>&2\r\n  exit /b 1\r\n) else (\r\n  echo git %*\r\n  exit /b 0\r\n)"
+    } else {
         r#"#!/usr/bin/env sh
 if [ "$1" = "config" ]; then
-    /usr/bin/git "$@"
+  PATH="$ORIG_PATH" git "$@"
 elif [ "$1" = "remote" ] && [ "$2" = "get-url" ]; then
-    exit 1
+  exit 1
 elif [ "$1" = "subtree" ] && [ "$2" = "pull" ]; then
-    echo >&2 "hint: use 'git subtree add'"
-    exit 1
+  echo >&2 "hint: use 'git subtree add'"
+  exit 1
 else
-    echo git "$@"
-    exit 0
+  echo git "$@"
+  exit 0
 fi
-"#,
-    )
-    .unwrap();
+"#
+    };
+
+    fs::write(&shim, script).unwrap();
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -63,16 +86,11 @@ fn connect_and_list_roundtrip() {
     let repo = setup_repo();
     let git_shim = fake_git_path(&repo);
 
+    let (path_env, orig_path) = path_vars(&git_shim);
     let mut cmd = Command::cargo_bin("gh-sync").unwrap();
     cmd.current_dir(repo.path())
-        .env(
-            "PATH",
-            format!(
-                "{}:{}",
-                git_shim.parent().unwrap().display(),
-                std::env::var("PATH").unwrap()
-            ),
-        )
+        .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
         .args(&[
             "connect",
             "app",
@@ -98,16 +116,13 @@ fn pull_falls_back_to_add() {
     let repo = setup_repo();
     let git_shim = fake_git_fail_pull(&repo);
 
-    let path_env = format!(
-        "{}:{}",
-        git_shim.parent().unwrap().display(),
-        std::env::var("PATH").unwrap()
-    );
+    let (path_env, orig_path) = path_vars(&git_shim);
 
     Command::cargo_bin("gh-sync")
         .unwrap()
         .current_dir(repo.path())
         .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
         .args(&["connect", "app", "git@github.com:ackkerman/spinning_donut.rs.git"])
         .assert()
         .success();
@@ -116,6 +131,7 @@ fn pull_falls_back_to_add() {
         .unwrap()
         .current_dir(repo.path())
         .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
         .args(&["pull", "app"])
         .assert()
         .success()
@@ -128,16 +144,13 @@ fn pull_with_custom_message() {
     // use failing pull shim so that fallback to add prints the command
     let git_shim = fake_git_fail_pull(&repo);
 
-    let path_env = format!(
-        "{}:{}",
-        git_shim.parent().unwrap().display(),
-        std::env::var("PATH").unwrap()
-    );
+    let (path_env, orig_path) = path_vars(&git_shim);
 
     Command::cargo_bin("gh-sync")
         .unwrap()
         .current_dir(repo.path())
         .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
         .args(&["connect", "app", "git@github.com:ackkerman/spinning_donut.rs.git"])
         .assert()
         .success();
@@ -146,6 +159,7 @@ fn pull_with_custom_message() {
         .unwrap()
         .current_dir(repo.path())
         .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
         .args(&["pull", "app", "-m", "custom"])
         .assert()
         .success()
@@ -157,16 +171,13 @@ fn remove_mapping() {
     let repo = setup_repo();
     let git_shim = fake_git_path(&repo);
 
-    let path_env = format!(
-        "{}:{}",
-        git_shim.parent().unwrap().display(),
-        std::env::var("PATH").unwrap()
-    );
+    let (path_env, orig_path) = path_vars(&git_shim);
 
     Command::cargo_bin("gh-sync")
         .unwrap()
         .current_dir(repo.path())
         .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
         .args(&["connect", "app", "git@github.com:ackkerman/spinning_donut.rs.git"])
         .assert()
         .success();
@@ -175,6 +186,7 @@ fn remove_mapping() {
         .unwrap()
         .current_dir(repo.path())
         .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
         .args(&["remove", "app"])
         .assert()
         .success()
@@ -184,6 +196,7 @@ fn remove_mapping() {
         .unwrap()
         .current_dir(repo.path())
         .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
         .arg("list")
         .assert()
         .success()


### PR DESCRIPTION
## Summary
- handle PATH using `join_paths` so tests work cross‑platform
- add Windows compatible git shim scripts
- use `ORIG_PATH` inside shims to call the real git

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6880bd6cd2b08330b23ef46b770a6e3e