### PR TITLE
feat/2025-07-31-push-message

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Synchronize a subdirectory of your repository with an external repository using 
 
 - **connect** – register a subdirectory ↔ remote URL mapping
 - **pull** – fetch from the remote and update the subtree (supports `-m` for merge message)
-- **push** – push local changes in the subtree back to the remote
+- **push** – push local changes in the subtree back to the remote (supports `-m` for commit message)
 - **list** – show current mappings
 - **remove** – delete a mapping
 
@@ -36,7 +36,7 @@ gh sync connect web-app git@github.com:ackkerman/nlo.git --branch dev_ui
 gh sync pull web-app -m "Update from remote"
 
 # Push local changes back
-gh sync push web-app
+gh sync push web-app -m "Sync subtree"
 
 # View mappings
 gh sync list

--- a/docs/About.md
+++ b/docs/About.md
@@ -8,8 +8,8 @@ gh-sync is a lightweight CLI tool for synchronizing a subdirectory of one Git re
   Register a mapping between a local subdirectory and a remote repository/branch.
 - `pull <subdir> [--branch <name>] [-m <message>]`
   Fetch from the configured remote and update the subtree using the given merge commit message.
-- `push <subdir> [--branch <name>]`  
-  Push local changes in the subtree back to the remote.
+- `push <subdir> [--branch <name>] [-m <message>]`
+  Push local changes in the subtree back to the remote using the provided commit message.
 - `remove <subdir>`  
   Delete the mapping from Git config.
 - `list`  
@@ -27,7 +27,7 @@ gh sync connect web-app git@github.com:example/remote.git --branch main
 gh sync pull web-app -m "Update from remote"
 
 # Push local updates back
-gh sync push web-app
+gh sync push web-app -m "Sync subtree"
 
 # Remove mapping
 gh sync remove web-app

--- a/src/gitops.rs
+++ b/src/gitops.rs
@@ -82,9 +82,17 @@ pub fn subtree_pull(
     }
 }
 
-pub fn subtree_push(repo: &Path, prefix: &str, remote: &str, branch: &str) -> Result<()> {
-    run(
-        repo,
-        &["subtree", "push", "--prefix", prefix, remote, branch],
-    )
+pub fn subtree_push(
+    repo: &Path,
+    prefix: &str,
+    remote: &str,
+    branch: &str,
+    message: Option<&str>,
+) -> Result<()> {
+    let mut args = vec!["subtree", "push", "--prefix", prefix, remote, branch];
+    if let Some(m) = message {
+        args.push("-m");
+        args.push(m);
+    }
+    run(repo, &args)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,9 @@ enum Commands {
         subdir: String,
         #[arg(short, long)]
         branch: Option<String>,
+        /// message for subtree push
+        #[arg(short, long)]
+        message: Option<String>,
     },
     /// SUBDIR のマッピングを削除
     Remove { subdir: String },
@@ -92,7 +95,11 @@ fn run() -> Result<()> {
             println!("Connected {subdir} ↔ {remote_url} ({branch})");
         }
 
-        Commands::Pull { subdir, branch, message } => {
+        Commands::Pull {
+            subdir,
+            branch,
+            message,
+        } => {
             let m = cfg
                 .mappings
                 .get(&subdir)
@@ -104,13 +111,17 @@ fn run() -> Result<()> {
             println!("Pulled {subdir} from {}/{}", m.remote, branch);
         }
 
-        Commands::Push { subdir, branch } => {
+        Commands::Push {
+            subdir,
+            branch,
+            message,
+        } => {
             let m = cfg
                 .mappings
                 .get(&subdir)
                 .with_context(|| format!("{subdir} not connected"))?;
             let branch = branch.unwrap_or_else(|| m.branch.clone());
-            subtree_push(&repo, &m.subdir, &m.remote, &branch)?;
+            subtree_push(&repo, &m.subdir, &m.remote, &branch, message.as_deref())?;
             println!("Pushed {subdir} to {}/{}", m.remote, branch);
         }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -125,11 +125,7 @@ fn pull_falls_back_to_add() {
         .current_dir(repo.path())
         .env("PATH", &path_env)
         .env("ORIG_PATH", &orig_path)
-        .args(&[
-            "connect",
-            "app",
-            "git@github.com:a/b.gitt",
-        ])
+        .args(&["connect", "app", "git@github.com:a/b.gitt"])
         .assert()
         .success();
 
@@ -157,11 +153,7 @@ fn pull_with_custom_message() {
         .current_dir(repo.path())
         .env("PATH", &path_env)
         .env("ORIG_PATH", &orig_path)
-        .args(&[
-            "connect",
-            "app",
-            "git@github.com:a/b.gitt",
-        ])
+        .args(&["connect", "app", "git@github.com:a/b.gitt"])
         .assert()
         .success();
 
@@ -171,6 +163,33 @@ fn pull_with_custom_message() {
         .env("PATH", &path_env)
         .env("ORIG_PATH", &orig_path)
         .args(&["pull", "app", "-m", "custom"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("-m custom"));
+}
+
+#[test]
+fn push_with_custom_message() {
+    let repo = setup_repo();
+    let git_shim = fake_git_path(&repo);
+
+    let (path_env, orig_path) = path_vars(&git_shim);
+
+    Command::cargo_bin("gh-sync")
+        .unwrap()
+        .current_dir(repo.path())
+        .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
+        .args(&["connect", "app", "git@github.com:a/b.gitt"])
+        .assert()
+        .success();
+
+    Command::cargo_bin("gh-sync")
+        .unwrap()
+        .current_dir(repo.path())
+        .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
+        .args(&["push", "app", "-m", "custom"])
         .assert()
         .success()
         .stdout(predicate::str::contains("-m custom"));
@@ -188,11 +207,7 @@ fn remove_mapping() {
         .current_dir(repo.path())
         .env("PATH", &path_env)
         .env("ORIG_PATH", &orig_path)
-        .args(&[
-            "connect",
-            "app",
-            "git@github.com:a/b.gitt",
-        ])
+        .args(&["connect", "app", "git@github.com:a/b.gitt"])
         .assert()
         .success();
 


### PR DESCRIPTION
## Summary
- support `-m`/`--message` for `push`
- pass message flag through to `git subtree push`
- document push `-m` option
- test new push message handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688b05ebb40c8330a62916d39593aa82