### PR TITLE
Fix handling of dots in mapping names

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -36,12 +36,8 @@ impl Config {
 
         for line in stdout.lines() {
             if let Some((key, value)) = line.split_once(' ') {
-                let mut parts = key.split('.');
-                if parts.next() != Some(CONFIG_PREFIX) {
-                    continue;
-                }
-                if let Some(name) = parts.next() {
-                    if let Some(field) = parts.next() {
+                if let Some(rem) = key.strip_prefix(&format!("{CONFIG_PREFIX}.")) {
+                    if let Some((name, field)) = rem.rsplit_once('.') {
                         let entry =
                             cfg.mappings
                                 .entry(name.to_string())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -114,6 +114,36 @@ fn connect_and_list_roundtrip() {
 }
 
 #[test]
+fn dotted_subdir_and_remote() {
+    let repo = setup_repo();
+    let git_shim = fake_git_path(&repo);
+
+    let (path_env, orig_path) = path_vars(&git_shim);
+
+    Command::cargo_bin("gh-sync")
+        .unwrap()
+        .current_dir(repo.path())
+        .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
+        .args(&[
+            "connect",
+            "tools/automaton.x",
+            "git@github.com:a/automaton.x.git",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("gh-sync")
+        .unwrap()
+        .current_dir(repo.path())
+        .env("PATH", &path_env)
+        .env("ORIG_PATH", &orig_path)
+        .args(&["pull", "tools/automaton.x"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn pull_falls_back_to_add() {
     let repo = setup_repo();
     let git_shim = fake_git_fail_pull(&repo);


### PR DESCRIPTION
## Summary
- correctly parse mappings whose subdirectory or remote names contain dots
- test dotted mapping to ensure `pull` works

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68995dde3a788330b2be6a28edd5848e